### PR TITLE
Hey! This pull request fixes 2 small bugs

### DIFF
--- a/XmlCData.cls
+++ b/XmlCData.cls
@@ -50,8 +50,10 @@ public class XmlCData
     //if any of ltReplace or gtReplace is null, the replacement strings will be defined by setReplacementStrings
     public static String addCDataNodes(String XmlString, String ltReplace, String gtReplace)
     {
-        if ((ltReplace==null) or (gtReplace==null))
+        if ((ltReplace==null) || (gtReplace==null))
+        {
             setReplacementStrings(XmlString);   //only for a read-only purpose document !
+        }
         else
         {
             /* @todo : check that ltReplace and gtReplace are not contained in XmlString, if yes, raise an error */
@@ -61,10 +63,9 @@ public class XmlCData
         Matcher m = CDataSectionPattern.matcher(XmlString);
         while (m.find())
         {
+            String txt = m.group(1).replace('<', lt).replace('>',gt).escapeXml();
             XmlString = XmlString.substring(0, m.start()) +
-                '<CDataSection lt="'+lt+'" gt="'+gt+'">'+
-                m.group(1).replace('<', lt).replace('>',gt) +
-                '</CDataSection>'
+                '<CDataSection lt="'+lt+'" gt="'+gt+'">'+ txt + '</CDataSection>'
                 +  XmlString.substring( m.end());
             m = CDataSectionPattern.matcher(XmlString);
         }

--- a/testXmlCData.cls
+++ b/testXmlCData.cls
@@ -6,7 +6,7 @@ public class testXmlCData {
     {
         String xml = '<root><node><![CDATA[some text with some < < and some > for test purpose]]></node><othernode>with nothing special</othernode><thirdNode><![CDATA[another test text]]></thirdNode></root>';
         Dom.Document doc = new Dom.Document();
-        doc.load(XmlCData.addCDataNodes(xml));
+        doc.load(XmlCData.addCDataNodes(xml, null, null));
         System.assertEquals(doc.toXmlString().indexOf('<!CDATA['), -1);
         System.assertEquals(doc.toXmlString().indexOf('text with some <'), -1);
         System.assertEquals((doc.toXmlString().indexOf('text with some')!=-1), true);


### PR DESCRIPTION
- The XmlCData.cls class wouldn't compile, because there was an "or" instead of an "||" in one place.
- The data that was in a CDATA section now needs to be xml escaped, as the data can contain XML entities.

For example, my CDATA sections had text like so:

Test & Data

and this failed on XML parse because of the "&". 

Thanks for the nice wrapper!
